### PR TITLE
New feature, you can now pass the desired event type to the hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,15 +6,16 @@ import { useEffect, useRef } from "react";
  *
  * @param  {(string | string[])} handlerKey - A key, key combo or array of combos according to Mousetrap documentation.
  * @param  { function } handlerCallback - A function that is triggered on key combo catch.
+ * @param  { string } evtType - A string that specifies the type of event to listen for. It can be 'keypress', 'keydown' or 'keyup'.
  */
-export default (handlerKey, handlerCallback) => {
+export default (handlerKey, handlerCallback, evtType) => {
   let actionRef = useRef(null);
   actionRef.current = handlerCallback;
 
   useEffect(() => {
     mousetrap.bind(handlerKey, (evt, combo) => {
       typeof actionRef.current === "function" && actionRef.current(evt, combo);
-    });
+    }, evtType);
     return () => {
       mousetrap.unbind(handlerKey);
     };


### PR DESCRIPTION
As the mousetrap docs say : 

> There is a third argument you can use to specify the type of event to listen for. It can be `keypress`, `keydown` or `keyup`.

This feature can now optionally be used with this hook.